### PR TITLE
Use the join return value for success

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -89,7 +89,7 @@ class domain_membership (
   $command = "(Get-WmiObject -Class Win32_ComputerSystem).JoinDomainOrWorkGroup('${domain}',${_password},'${username}@${domain}',${_machine_ou},${join_options})"
 
   exec { 'join_domain':
-    command  => $command,
+    command  => "exit ${command}.ReturnValue",
     unless   => "if((Get-WmiObject -Class Win32_ComputerSystem).domain -ne '${domain}'){ exit 1 }",
     provider => powershell,
   }


### PR DESCRIPTION
Without this patch, the exec always reports a success, even when the
join fails.