### PR TITLE
added reboot after join domain at the end of the puppet run

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Parameters
  * ```password```     - Password for domain joining user.
  * ```machine_ou```   - [Optional] OU in the directory for the machine account to be created in.
  * ```resetpw```      - [Optional] Whether or not to force machine password reset if it becomes out of sync with the domain.
+ * ```reboot```       - [Optional] Whether or not to reboot when the machine joins the domain. (reboot by default)
  * ```join_options``` - [Optional] A bit field for options to use when joining the domain. See http://msdn.microsoft.com/en-us/library/aa392154(v=vs.85).aspx Defaults to '1' (default domain join).
 
 Usage
@@ -31,6 +32,7 @@ Contact
 Changelog
 ---------
 
+* Wout van Heeswijk <wout.van.heeswijk@gmail.com> -- Added a reboot option
 * Ben Ford <ben.ford@puppetlabs.com> -- Use the join return value for success
 * Thomas Linkin <trlinkin@gmail.com> -- Update module dependancy
 * Thomas Linkin <trlinkin@gmail.com> -- Move license to LICENSE file to conform with Forge rules.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -30,6 +30,10 @@
 #   See: http://msdn.microsoft.com/en-us/library/aa392154(v=vs.85).aspx
 #   Defaults to '1'.
 #
+# [*reboot*]
+#   Wether or not the computer should reboot after a domain join.
+#   Valid values are 'true' and 'false'. Defaults to 'true'.
+#
 # === Examples
 #
 #  class { domain_membership:
@@ -55,6 +59,7 @@ class domain_membership (
   $secure_password = false,
   $machine_ou      = undef,
   $resetpw         = true,
+  $reboot          = true,
   $join_options     = '1',
 ){
 
@@ -100,6 +105,13 @@ class domain_membership (
       unless   => "if ($(nltest /sc_verify:${domain}) -match 'ERROR_INVALID_PASSWORD') {exit 1}",
       provider => powershell,
       require  => Exec['join_domain'],
+    }
+  }
+
+  if $reboot {
+    reboot { 'after':
+      subscribe => Exec['join_domain'],
+      apply     => finished,
     }
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "trlinkin-domain_membership",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "author": "Thomas Linkin <trlinkin@gmail.com>",
   "license": "Licensed under (Apache 2.0)",
   "summary": "Module for managing AD domain membership of Windows systems.",
@@ -15,6 +15,7 @@
    ],
   "dependencies": [
     { "name": "puppetlabs/powershell", "version_requirement": ">= 1.0.1" },
-    { "name": "puppetlabs/stdlib", "version_requirement": ">= 4.1.0" }
+    { "name": "puppetlabs/stdlib", "version_requirement": ">= 4.1.0" },
+    { "name": "puppetlabs/reboot", "version_requirement": ">= 0.9.1" }
   ]
 }


### PR DESCRIPTION
I've added an optional but default reboot after the domain join. That way an automated deployment of windows will join the domain, reboot and apply domain policies.