### PR TITLE
Add reboot_timeout param

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Manage Active Directory domain membership with this module.
  * ```resetpw```      - [Optional] Whether or not to force machine password reset if it becomes out of sync with the domain.
  * ```reboot```       - [Optional] Whether or not to reboot when the machine joins the domain. (reboot by default)
  * ```reboot_apply``` - [Optional] If `reboot` is true, this controls the `apply` parameter. (defaults to 'finished')
+  * ```reboot_timeout``` - [Optional] If `reboot` is true, this controls the `timeout` parameter. (defaults to '60')
  * ```join_options``` - [Optional] A bit field for options to use when joining the domain. See http://msdn.microsoft.com/en-us/library/aa392154(v=vs.85).aspx Defaults to '1' (default domain join).
  * ```user_domain```  - [Optional] Domain of user account used to join machine, if different from domain machine will be joined to.  If not specified, the value passed to the `domain` parameter will be used.
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -59,6 +59,7 @@ class domain_membership (
   $resetpw         = true,
   $reboot          = true,
   $reboot_apply    = 'finished',
+  $reboot_timeout  = '60',
   $join_options    = '1',
   $user_domain     = undef,
 ){
@@ -125,6 +126,7 @@ class domain_membership (
     reboot { 'after_domain_join':
       subscribe => Exec['join_domain'],
       apply     => $reboot_apply,
+      timeout   => $reboot_timeout,
     }
   }
 }


### PR DESCRIPTION
This will allow users to manage the timeout parameter on the reboot resource to override the default of '60'


We have a need for a longer reboot timeout period once the catalog is finished. I am currently overriding the default of '60' by setting a Reboot{} resource default. I would like to make this a little cleaner.