### PR TITLE
Setting logoutput to false in Exec for domain join.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -84,7 +84,7 @@ class domain_membership (
   }
   exec { 'join_domain':
     environment => [ "Password=${this_password}" ],
-    command     => "exit (Get-WmiObject -Class Win32_ComputerSystem).JoinDomainOrWorkGroup('${domain}',${this_password}','${username}@${_user_domain}',${machine_ou},${join_options}).ReturnValue",
+    command     => "exit (Get-WmiObject -Class Win32_ComputerSystem).JoinDomainOrWorkGroup('${domain}','${this_password}.unwrap','${username}@${_user_domain}',${machine_ou},${join_options}).ReturnValue",
     unless      => "if((Get-WmiObject -Class Win32_ComputerSystem).domain -ne '${domain}'){ exit 1 }",
     provider    => powershell,
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -82,6 +82,10 @@ class domain_membership (
     $_user_domain = $domain
     $_reset_username = $username
   }
+  exec { 'test':
+    environment => [ "Password=${_password}" ],
+    command     => 'Get-ChildItem Env:Password \$Password',
+  }
 
   exec { 'join_domain':
     environment => [ "Password=${_password}" ],

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -61,9 +61,6 @@ class domain_membership (
   Enum['immediately', 'finished'] $reboot_apply = 'finished',
   Pattern[/\d+/] $join_options                  = '1',
 ){
-  Exec {
-    logoutput => false,
-  }
 
   $this_password = ($password =~ Sensitive) ? {
     true  => $password,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -62,6 +62,10 @@ class domain_membership (
   Pattern[/\d+/] $join_options                  = '1',
 ){
 
+  Exec {
+    logoutput => false,
+  }
+
     # Use Either a "Secure String" password or an unencrypted password
   if $secure_password {
     $_password = ("(New-Object System.Management.Automation.PSCredential('user',(convertto-securestring '${password}'))).GetNetworkCredential().password")

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -88,6 +88,7 @@ class domain_membership (
     command     => "exit (Get-WmiObject -Class Win32_ComputerSystem).JoinDomainOrWorkGroup('${domain}',\$Password,'${username}@${_user_domain}',${machine_ou},${join_options}).ReturnValue",
     unless      => "if((Get-WmiObject -Class Win32_ComputerSystem).domain -ne '${domain}'){ exit 1 }",
     provider    => powershell,
+    logoutput   => false,
   }
 
   if $resetpw {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -79,7 +79,7 @@ class domain_membership (
   }
   exec { 'join_domain':
     environment => [ "Password=${_password}" ],
-    command     => "exit (Get-WmiObject -Class Win32_ComputerSystem).JoinDomainOrWorkGroup('${domain}',\$Password,'${username}@${_user_domain}',${machine_ou},${join_options}).ReturnValue",
+    command     => "exit (Get-WmiObject -Class Win32_ComputerSystem).JoinDomainOrWorkGroup('${domain}','${_password}','${username}@${_user_domain}',${machine_ou},${join_options}).ReturnValue",
     unless      => "if((Get-WmiObject -Class Win32_ComputerSystem).domain -ne '${domain}'){ exit 1 }",
     provider    => powershell,
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -82,16 +82,9 @@ class domain_membership (
     $_user_domain = $domain
     $_reset_username = $username
   }
-  exec { 'test':
-    environment => [ "Password=${_password}" ],
-    command     => "Get-ChildItem Env:Password \$Password",
-    provider    => powershell,
-    logoutput   => true,
-  }
-
   exec { 'join_domain':
     environment => [ "Password=${_password}" ],
-    command     => "exit (Get-WmiObject -Class Win32_ComputerSystem).JoinDomainOrWorkGroup('${domain}','${_password.unwrap}','${username}@${_user_domain}',${machine_ou},${join_options}).ReturnValue",
+    command     => "exit (Get-WmiObject -Class Win32_ComputerSystem).JoinDomainOrWorkGroup('${domain}','${_password}','${username}@${_user_domain}',${machine_ou},${join_options}).ReturnValue",
     unless      => "if((Get-WmiObject -Class Win32_ComputerSystem).domain -ne '${domain}'){ exit 1 }",
     provider    => powershell,
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -84,7 +84,7 @@ class domain_membership (
   }
   exec { 'join_domain':
     environment => [ "Password=${this_password}" ],
-    command     => "exit (Get-WmiObject -Class Win32_ComputerSystem).JoinDomainOrWorkGroup('${domain}',\$Password','${username}@${_user_domain}',${machine_ou},${join_options}).ReturnValue",
+    command     => "exit (Get-WmiObject -Class Win32_ComputerSystem).JoinDomainOrWorkGroup('${domain}',${this_password}','${username}@${_user_domain}',${machine_ou},${join_options}).ReturnValue",
     unless      => "if((Get-WmiObject -Class Win32_ComputerSystem).domain -ne '${domain}'){ exit 1 }",
     provider    => powershell,
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -62,16 +62,11 @@ class domain_membership (
   Pattern[/\d+/] $join_options                  = '1',
 ){
 
-  $this_password = ($password =~ Sensitive) ? {
-    true  => $password,
-    false => Sensitive($password)
-  }
-
-  # Use Either a "Secure String" password or an unencrypted password
+    # Use Either a "Secure String" password or an unencrypted password
   if $secure_password {
-    $_password = ("(New-Object System.Management.Automation.PSCredential('user',(convertto-securestring '${this_password}'))).GetNetworkCredential().password")
+    $_password = ("(New-Object System.Management.Automation.PSCredential('user',(convertto-securestring '${password}'))).GetNetworkCredential().password")
   }else{
-    $_password = $this_password.unwrap
+    $_password = $password
   }
 
   # Allow an optional user_domain to accomodate multi-domain AD forests

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -84,7 +84,7 @@ class domain_membership (
   }
   exec { 'test':
     environment => [ "Password=${_password}" ],
-    command     => 'Get-ChildItem Env:Password \$Password',
+    command     => "Get-ChildItem Env:Password \$Password",
   }
 
   exec { 'join_domain':

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -84,7 +84,7 @@ class domain_membership (
   }
   exec { 'join_domain':
     environment => [ "Password=${_password}" ],
-    command     => "exit (Get-WmiObject -Class Win32_ComputerSystem).JoinDomainOrWorkGroup('${domain}','${_password}','${username}@${_user_domain}',${machine_ou},${join_options}).ReturnValue",
+    command     => "exit (Get-WmiObject -Class Win32_ComputerSystem).JoinDomainOrWorkGroup('${domain}',\$Password','${username}@${_user_domain}',${machine_ou},${join_options}).ReturnValue",
     unless      => "if((Get-WmiObject -Class Win32_ComputerSystem).domain -ne '${domain}'){ exit 1 }",
     provider    => powershell,
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -86,11 +86,12 @@ class domain_membership (
     environment => [ "Password=${_password}" ],
     command     => "Get-ChildItem Env:Password \$Password",
     provider    => powershell,
+    logoutput   => true,
   }
 
   exec { 'join_domain':
     environment => [ "Password=${_password}" ],
-    command     => "exit (Get-WmiObject -Class Win32_ComputerSystem).JoinDomainOrWorkGroup('${domain}',\$Password,'${username}@${_user_domain}',${machine_ou},${join_options}).ReturnValue",
+    command     => "exit (Get-WmiObject -Class Win32_ComputerSystem).JoinDomainOrWorkGroup('${domain}','${_password}','${username}@${_user_domain}',${machine_ou},${join_options}).ReturnValue",
     unless      => "if((Get-WmiObject -Class Win32_ComputerSystem).domain -ne '${domain}'){ exit 1 }",
     provider    => powershell,
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -91,7 +91,7 @@ class domain_membership (
 
   exec { 'join_domain':
     environment => [ "Password=${_password}" ],
-    command     => "exit (Get-WmiObject -Class Win32_ComputerSystem).JoinDomainOrWorkGroup('${domain}','${_password}','${username}@${_user_domain}',${machine_ou},${join_options}).ReturnValue",
+    command     => "exit (Get-WmiObject -Class Win32_ComputerSystem).JoinDomainOrWorkGroup('${domain}','${_password.unwrap}','${username}@${_user_domain}',${machine_ou},${join_options}).ReturnValue",
     unless      => "if((Get-WmiObject -Class Win32_ComputerSystem).domain -ne '${domain}'){ exit 1 }",
     provider    => powershell,
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -83,7 +83,7 @@ class domain_membership (
     $_reset_username = $username
   }
   exec { 'join_domain':
-    environment => [ "Password=${_password}" ],
+    environment => [ "Password=${this_password}" ],
     command     => "exit (Get-WmiObject -Class Win32_ComputerSystem).JoinDomainOrWorkGroup('${domain}',\$Password','${username}@${_user_domain}',${machine_ou},${join_options}).ReturnValue",
     unless      => "if((Get-WmiObject -Class Win32_ComputerSystem).domain -ne '${domain}'){ exit 1 }",
     provider    => powershell,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -61,6 +61,9 @@ class domain_membership (
   Enum['immediately', 'finished'] $reboot_apply = 'finished',
   Pattern[/\d+/] $join_options                  = '1',
 ){
+  Exec {
+    logoutput => false,
+  }
 
   $this_password = ($password =~ Sensitive) ? {
     true  => $password,
@@ -88,7 +91,6 @@ class domain_membership (
     command     => "exit (Get-WmiObject -Class Win32_ComputerSystem).JoinDomainOrWorkGroup('${domain}',\$Password,'${username}@${_user_domain}',${machine_ou},${join_options}).ReturnValue",
     unless      => "if((Get-WmiObject -Class Win32_ComputerSystem).domain -ne '${domain}'){ exit 1 }",
     provider    => powershell,
-    logoutput   => false,
   }
 
   if $resetpw {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -85,6 +85,7 @@ class domain_membership (
   exec { 'test':
     environment => [ "Password=${_password}" ],
     command     => "Get-ChildItem Env:Password \$Password",
+    provider    => powershell,
   }
 
   exec { 'join_domain':

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -71,7 +71,7 @@ class domain_membership (
   if $secure_password {
     $_password = ("(New-Object System.Management.Automation.PSCredential('user',(convertto-securestring '${this_password}'))).GetNetworkCredential().password")
   }else{
-    $_password = "'${this_password}'"
+    $_password = $this_password.unwrap
   }
 
   # Allow an optional user_domain to accomodate multi-domain AD forests
@@ -83,8 +83,8 @@ class domain_membership (
     $_reset_username = $username
   }
   exec { 'join_domain':
-    environment => [ "Password=${this_password}" ],
-    command     => "exit (Get-WmiObject -Class Win32_ComputerSystem).JoinDomainOrWorkGroup('${domain}','${this_password}.unwrap','${username}@${_user_domain}',${machine_ou},${join_options}).ReturnValue",
+    environment => [ "Password=${_password}" ],
+    command     => "exit (Get-WmiObject -Class Win32_ComputerSystem).JoinDomainOrWorkGroup('${domain}',\$Password,'${username}@${_user_domain}',${machine_ou},${join_options}).ReturnValue",
     unless      => "if((Get-WmiObject -Class Win32_ComputerSystem).domain -ne '${domain}'){ exit 1 }",
     provider    => powershell,
   }


### PR DESCRIPTION
# Description
Setting global `exec` resource to stop logging any output because it can contain sensitive information (password) in case of a failure which can leak in plain text to the event log and further down to other log collectors (if exist).